### PR TITLE
Fea/add matches page

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "start": "parcel src/assets/index.html",
-    "build": "rm -rf public && parcel build src/assets/index.html --out-dir public"
+    "build": "rm -rf public && parcel build src/assets/index.html --out-dir public --no-source-maps"
   },
   "devDependencies": {
     "eslint": "^6.8.0",

--- a/src/app/components/MatchResults/Results/index.js
+++ b/src/app/components/MatchResults/Results/index.js
@@ -10,7 +10,7 @@ import Team from '../Team'
 import { Container, Match } from './styled'
 
 const Results = () => {
-  const matches = useSelector(state => state.matches)
+  const matches = useSelector(state => state.matches.items.search)
 
   const handleClick = match =>
     navigate(`/match/${match.match_id}`)
@@ -18,7 +18,7 @@ const Results = () => {
   return (
     <Container>
       {
-        matches.items.map(match =>
+        matches.map(match =>
           <Match
             key={match.match_id}
             onClick={() => handleClick(match)}

--- a/src/app/components/MatchResults/Team/styled.js
+++ b/src/app/components/MatchResults/Team/styled.js
@@ -2,4 +2,5 @@ import styled from 'styled-components'
 
 export const Container = styled.div`
   display: flex;
+  padding: .5rem 0;
 `

--- a/src/app/components/MatchResults/index.js
+++ b/src/app/components/MatchResults/index.js
@@ -5,7 +5,7 @@ import Results from './Results'
 import Result404 from 'app/components/Result404'
 
 const MatchResults = () => {
-  const matches = useSelector(state => state.matches.items)
+  const matches = useSelector(state => state.matches.items.search)
 
   return (
     matches.length > 0

--- a/src/app/components/NavBar/index.js
+++ b/src/app/components/NavBar/index.js
@@ -7,8 +7,7 @@ const NavBar = () => {
     <Container>
       <Link to='/'>Home</Link>
       <Link to='/matchup'>Find Matchup</Link>
-      <Link to='/'>Players</Link>
-      <Link to='/'>Matches</Link>
+      <Link to='/matches'>Matches</Link>
       <Link to='/teams'>Teams</Link>
     </Container>
   )

--- a/src/app/components/Router/index.js
+++ b/src/app/components/Router/index.js
@@ -8,6 +8,7 @@ import Home from 'app/pages/Home'
 import FindMatchup from 'app/pages/FindMatchup'
 import SearchResults from 'app/pages/SearchResults'
 import PlayerProfile from 'app/components/PlayerProfile'
+import Matches from 'app/pages/Matches'
 import Match from 'app/components/Match'
 import Teams from 'app/pages/Teams'
 import Team from 'app/components/Team'
@@ -34,6 +35,8 @@ const AppRouter = () => {
           <FindMatchup path='matchup' />
           <SearchResults path='search/:query/:input' />
           <PlayerProfile path='player/:id' />
+
+          <Matches path='matches' />
           <Match path='match/:id' />
 
           <Teams path='teams' />

--- a/src/app/pages/Matches/ProMatches/index.js
+++ b/src/app/pages/Matches/ProMatches/index.js
@@ -1,0 +1,50 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { navigate } from '@reach/router'
+
+import { getGameDuration, getTimeElapsed } from 'app/helpers/utils'
+
+import Text from 'app/components/core/Text'
+
+import { Container, Match } from './styled'
+
+const ProMatches = ({ matches }) => {
+  const handleClick = id =>
+    navigate(`/match/${id}`)
+
+  return (
+    <Container>
+      <Text component='h1'>pro matches</Text>
+      {
+        matches
+          .filter((match, index) => index < 5)
+          .map(match =>
+            <Match
+              key={match.match_id}
+              onClick={() => handleClick(match.match_id)}
+            >
+              <div>
+                <Text>{match.match_id}</Text>
+                <Text>{match.league_name}</Text>
+              </div>
+
+              <Text>
+                {match.radiant_name}
+                <br />vs<br />
+                {match.dire_name}
+              </Text>
+
+              <Text>{getGameDuration(match.duration)}</Text>
+              <Text>{getTimeElapsed(match.start_time)}</Text>
+            </Match>
+          )
+      }
+    </Container>
+  )
+}
+
+ProMatches.propTypes = {
+  matches: PropTypes.array
+}
+
+export default ProMatches

--- a/src/app/pages/Matches/ProMatches/styled.js
+++ b/src/app/pages/Matches/ProMatches/styled.js
@@ -1,0 +1,27 @@
+import styled from 'styled-components'
+
+import theme from 'app/helpers/theme'
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
+`
+
+export const Match = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+  transition: .3s;
+
+  * {
+    flex: 1;
+  }
+
+  &:hover {
+    cursor: pointer;
+    background: ${theme.colors.hover};
+  }
+`

--- a/src/app/pages/Matches/PublicMatches/index.js
+++ b/src/app/pages/Matches/PublicMatches/index.js
@@ -1,0 +1,69 @@
+import React from 'react'
+import PropTypes from 'prop-types'
+import { navigate } from '@reach/router'
+
+import {
+  getLobbyType,
+  getGameMode,
+  getGameDuration,
+  getTimeElapsed
+} from 'app/helpers/utils'
+
+import Text from 'app/components/core/Text'
+import Team from 'app/components/MatchResults/Team'
+
+import { Container, Match } from './styled'
+
+const PublicMatches = ({ matches }) => {
+  const handleClick = id =>
+    navigate(`/match/${id}`)
+
+  return (
+    <Container>
+      <Text component='h1'>public matches</Text>
+      {
+        matches
+          .filter((match, index) => index < 5)
+          .map(match =>
+            <Match
+              key={match.match_id}
+              onClick={() => handleClick(match.match_id)}
+            >
+              <Text>{match.match_id}</Text>
+
+              <div>
+                <Text>{getGameMode(match.game_mode)}</Text>
+                <Text>{getLobbyType(match.lobby_type)}</Text>
+                <Text>{`avg mmr: ${match.avg_mmr}`}</Text>
+              </div>
+
+              <div>
+                <Team heroes={
+                  match.radiant_team
+                    .split(',')
+                    .map(hero => parseInt(hero))
+                }
+                />
+
+                <Team heroes={
+                  match.dire_team
+                    .split(',')
+                    .map(hero => parseInt(hero))
+                }
+                />
+              </div>
+
+              <Text>{getGameDuration(match.duration)}</Text>
+              <Text>{getTimeElapsed(match.start_time)}</Text>
+            </Match>
+          )
+      }
+    </Container>
+  )
+}
+
+PublicMatches.propTypes = {
+  matches: PropTypes.array
+}
+
+export default PublicMatches

--- a/src/app/pages/Matches/PublicMatches/styled.js
+++ b/src/app/pages/Matches/PublicMatches/styled.js
@@ -1,0 +1,28 @@
+import styled from 'styled-components'
+
+import theme from 'app/helpers/theme'
+
+export const Container = styled.div`
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 100%;
+  padding-top: 3rem;
+`
+
+export const Match = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1rem 0;
+  transition: .3s;
+
+  * {
+    flex: 1;
+  }
+
+  &:hover {
+    cursor: pointer;
+    background: ${theme.colors.hover};
+  }
+`

--- a/src/app/pages/Matches/index.js
+++ b/src/app/pages/Matches/index.js
@@ -1,0 +1,30 @@
+import React, { useEffect } from 'react'
+import { useSelector, useDispatch } from 'react-redux'
+
+import { isEmpty } from 'app/helpers/utils'
+import { fetchAllMatches } from 'app/redux/actions/matches'
+
+import ProMatches from './ProMatches'
+import PublicMatches from './PublicMatches'
+
+import { Container } from './styled'
+
+const Matches = () => {
+  const dispatch = useDispatch()
+  const matches = useSelector(state => state.matches.items)
+
+  useEffect(() => {
+    dispatch(fetchAllMatches())
+  }, [])
+
+  return (
+    !isEmpty(matches.proMatches) &&
+    !isEmpty(matches.publicMatches) &&
+      <Container>
+        <ProMatches matches={matches.proMatches} />
+        <PublicMatches matches={matches.publicMatches} />
+      </Container>
+  )
+}
+
+export default Matches

--- a/src/app/pages/Matches/styled.js
+++ b/src/app/pages/Matches/styled.js
@@ -1,0 +1,11 @@
+import styled from 'styled-components'
+
+import theme from 'app/helpers/theme'
+
+export const Container = styled.div`
+  display: flex;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  background: ${theme.colors.background};
+  padding: 3rem;
+`

--- a/src/app/redux/actions/matches.js
+++ b/src/app/redux/actions/matches.js
@@ -35,3 +35,23 @@ export const fetchMatchups = (idA, idB) => {
       .then(data => dispatch(receiveMatches(data)))
   }
 }
+
+export const receiveAllMatches = (proMatches, publicMatches) => ({
+  type: 'RECEIVE_ALL_MATCHES',
+  proMatches: proMatches,
+  publicMatches: publicMatches,
+})
+
+export const fetchAllMatches = () => {
+  return dispatch => {
+    dispatch(resetState())
+    dispatch(requestMatches())
+
+    return Promise.all([
+      fetch('https://api.opendota.com/api/proMatches')
+        .then(response => response.json()),
+      fetch('https://api.opendota.com/api/publicMatches?mmr_descending=1')
+        .then(response => response.json())
+    ]).then(values => dispatch(receiveAllMatches(values[0], values[1])))
+  }
+}

--- a/src/app/redux/reducers/matches.js
+++ b/src/app/redux/reducers/matches.js
@@ -1,6 +1,10 @@
 const initialState = {
   isFetching: false,
-  items: [],
+  items: {
+    search: [],
+    proMatches: [],
+    publicMatches: [],
+  },
   selected: {}
 }
 
@@ -12,18 +16,32 @@ const matches = (state = initialState, action) => {
         isFetching: true
       }
 
-    case 'RECEIVE_MATCHES':
-      return {
-        ...state,
-        isFetching: false,
-        items: action.items
-      }
-
     case 'RECEIVE_SELECTED_MATCH':
       return {
         ...state,
         isFetching: false,
         selected: action.selected
+      }
+
+    case 'RECEIVE_MATCHES':
+      return {
+        ...state,
+        isFetching: false,
+        items: {
+          ...state.items,
+          search: action.items
+        }
+      }
+
+    case 'RECEIVE_ALL_MATCHES':
+      return {
+        ...state,
+        isFetching: false,
+        items: {
+          ...state.items,
+          proMatches: action.proMatches,
+          publicMatches: action.publicMatches,
+        }
       }
 
     default:


### PR DESCRIPTION
- added --no-source-maps flag to yarn build
- updated redux structure for pages: now items is an object with search, proMatches and publicMatches properties
- updated match components that relied on old redux structure
- added Matches pages (ProMatches and PublicMatches subcomponents)
- added Matches to Router and NavBar 