### PR TITLE
Fix/boxshadow breadcrumbs pages

### DIFF
--- a/src/app/components/MatchupFinder/styled.js
+++ b/src/app/components/MatchupFinder/styled.js
@@ -8,7 +8,7 @@ export const Container = styled.div`
   align-items: center;
   padding: 3rem;
   background: ${theme.colors.background};
-  box-shadow: ${theme.boxShadow};
+  box-shadow: ${theme.boxShadow.noBreadcrumbs};
 `
 
 export const Form = styled.form`

--- a/src/app/components/SearchBox/styled.js
+++ b/src/app/components/SearchBox/styled.js
@@ -11,7 +11,7 @@ export const Container = styled.div`
   width: 100%;
   padding: 3rem;
   background: ${theme.colors.background};
-  box-shadow: ${theme.boxShadow};
+  box-shadow: ${theme.boxShadow.noBreadcrumbs};
 `
 
 export const Form = styled(CoreForm)`

--- a/src/app/components/core/Tabs/styled.js
+++ b/src/app/components/core/Tabs/styled.js
@@ -5,7 +5,7 @@ export const Container = styled.div`
   display: flex;
   flex-direction: column;
   width: 100%;
-  box-shadow: ${theme.boxShadow};
+  box-shadow: ${theme.boxShadow.noBreadcrumbs};
 `
 
 export const TabsContainer = styled.div`

--- a/src/app/helpers/theme.js
+++ b/src/app/helpers/theme.js
@@ -26,9 +26,12 @@ const variants = {
   }
 }
 
-const navbarHeight = '55px'
+const boxShadow = {
+  default: '10px 30px 20px 10px rgba(0,0,0,0.75);',
+  noBreadcrumbs: '10px 10px 20px 10px rgba(0,0,0,0.75);',
+}
 
-const boxShadow = '10px 0px 20px 10px rgba(0,0,0,0.75);'
+const navbarHeight = '55px'
 
 const theme = {
   colors,

--- a/src/app/pages/Matches/Index/styled.js
+++ b/src/app/pages/Matches/Index/styled.js
@@ -1,11 +1,4 @@
 import styled from 'styled-components'
 
-import theme from 'app/helpers/theme'
-
 export const Container = styled.div`
-  display: flex;
-  justify-content: space-between;
-  flex-wrap: wrap;
-  background: ${theme.colors.background};
-  box-shadow: ${theme.boxShadow};
 `

--- a/src/app/pages/Matches/styled.js
+++ b/src/app/pages/Matches/styled.js
@@ -7,7 +7,7 @@ export const Container = styled.div`
   justify-content: space-between;
   flex-wrap: wrap;
   background: ${theme.colors.background};
-  box-shadow: ${theme.boxShadow};
+  box-shadow: ${theme.boxShadow.default};
   padding: 3rem;
 
   & > div{

--- a/src/app/pages/Player/styled.js
+++ b/src/app/pages/Player/styled.js
@@ -5,5 +5,5 @@ import theme from 'app/helpers/theme'
 export const Container = styled.div`
   padding: 3rem;
   background: ${theme.colors.background};
-  box-shadow: ${theme.boxShadow};
+  box-shadow: ${theme.boxShadow.default};
 `

--- a/src/app/pages/Teams/styled.js
+++ b/src/app/pages/Teams/styled.js
@@ -7,7 +7,7 @@ export const Container = styled.div`
   justify-content: space-between;
   flex-wrap: wrap;
   background: ${theme.colors.background};
-  box-shadow: ${theme.boxShadow};
+  box-shadow: ${theme.boxShadow.default};
   padding: 3rem;
 `
 


### PR DESCRIPTION
Containers boxshadow are going through Breadcrumbs, making it look weird:

- added new boxSHadow variant style
- applied new boxShadow variants (also removed boxshadow from Matches index page, was causing background to go full black)