### PR TITLE
FIX: tooltip only rendered if there is content for it

### DIFF
--- a/src/app/components/core/Tooltip/index.js
+++ b/src/app/components/core/Tooltip/index.js
@@ -6,9 +6,12 @@ import { Container, TooltipContainer } from './styled'
 const Tooltip = ({ content, children }) => {
   return (
     <Container>
-      <TooltipContainer>
-        <span>{content}</span>
-      </TooltipContainer>
+      {
+        content &&
+          <TooltipContainer>
+            <span>{content}</span>
+          </TooltipContainer>
+      }
 
       {children}
     </Container>


### PR DESCRIPTION
Quick Tooltip fix:
- Tooltip only renders if there is content