### PR TITLE
Fea/add pagination

### DIFF
--- a/src/app/components/BackToTop/index.js
+++ b/src/app/components/BackToTop/index.js
@@ -1,0 +1,10 @@
+import React from 'react'
+
+import { Button } from './styled'
+
+const BackToTop = () =>
+  <Button onClick={() => scrollTo(0, 0)}>
+    back to top ^
+  </Button>
+
+export default BackToTop

--- a/src/app/components/BackToTop/styled.js
+++ b/src/app/components/BackToTop/styled.js
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+import CoreButton from 'app/components/core/Button'
+
+export const Button = styled(CoreButton)`
+  width: max-content;
+  margin: 2rem auto 0;
+`

--- a/src/app/components/Matches/Index/ProMatches/index.js
+++ b/src/app/components/Matches/Index/ProMatches/index.js
@@ -55,7 +55,7 @@ const ProMatches = () => {
                   {getGameDuration(match.duration)}
                 </Cell>
 
-                <Cell id='when'>
+                <Cell id='when' variant='lastCell'>
                   {getTimeElapsed(match.start_time)}
                 </Cell>
               </tr>

--- a/src/app/components/Matches/Index/PublicMatches/index.js
+++ b/src/app/components/Matches/Index/PublicMatches/index.js
@@ -81,7 +81,7 @@ const PublicMatches = () => {
                   {getGameDuration(match.duration)}
                 </Cell>
 
-                <Cell id='when'>
+                <Cell id='when' variant='lastCell'>
                   {getTimeElapsed(match.start_time)}
                 </Cell>
               </tr>

--- a/src/app/components/Matches/Match/Team/index.js
+++ b/src/app/components/Matches/Match/Team/index.js
@@ -87,7 +87,7 @@ const Team = ({ players }) => {
                 {formatNumber(player.hero_healing)}
               </Cell>
 
-              <Cell id='items' width='1%'>
+              <Cell id='items' variant='lastCell'>
                 <Items>
                   <Inventory>
                     {

--- a/src/app/components/Matches/ProMatches/index.js
+++ b/src/app/components/Matches/ProMatches/index.js
@@ -1,24 +1,21 @@
-import React, { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import React, { useState } from 'react'
+import { useSelector } from 'react-redux'
 import { navigate } from '@reach/router'
 
-import { fetchProMatches } from 'app/redux/actions/matches'
-
-import {
-  isEmpty,
-  getGameDuration,
-  getTimeElapsed,
-} from 'app/helpers/utils'
+import { getGameDuration, getTimeElapsed } from 'app/helpers/utils'
 
 import Text from 'app/components/core/Text'
 import Table from 'app/components/core/Table'
 import Cell from 'app/components/core/Table/Cell'
 
-import { Container } from './styled'
+import Pagination from 'app/components/Pagination'
+import BackToTop from 'app/components/BackToTop'
+
+import { Container, PaginationContainer } from './styled'
 
 const ProMatches = () => {
-  const dispatch = useDispatch()
-  const matches = useSelector(state => state.matches.items.proMatches)
+  const allMatches = useSelector(state => state.matches.items.proMatches)
+  const [matches, setMatches] = useState(allMatches.slice(0, 25))
 
   const columns = [
     'League',
@@ -30,18 +27,23 @@ const ProMatches = () => {
   const handleClick = id =>
     navigate(`/matches/${id}`)
 
-  useEffect(() => {
-    dispatch(fetchProMatches())
-  }, [])
-
-  return !isEmpty(matches) &&
+  return (
     <Container>
-      <Text component='h1'>
-        pro matches
-      </Text>
-      <Text padding='1rem 0'>
-        {`showing ${matches.length} matches`}
-      </Text>
+      <PaginationContainer>
+        <div>
+          <Text component='h2' padding='0 0 .5rem 0'>
+            pro matches
+          </Text>
+          <Text>
+            {`showing ${matches.length} matches`}
+          </Text>
+        </div>
+
+        <Pagination
+          array={allMatches}
+          setArray={setMatches}
+        />
+      </PaginationContainer>
 
       <Table columns={columns}>
         {
@@ -50,29 +52,33 @@ const ProMatches = () => {
               key={match.match_id}
               onClick={() => handleClick(match.match_id)}
             >
-              <Cell id='league'>
-                <div>
-                  <Text>{match.league_name}</Text>
-                  <Text>{match.match_id}</Text>
-                </div>
+              <Cell id='league' width='350px'>
+                <Text variant='hideOverflow'>
+                  {match.league_name}
+                </Text>
               </Cell>
 
-              <Cell id='teams'>
-                {`${match.radiant_name} vs ${match.dire_name}`}
+              <Cell id='teams' width='350px'>
+                <Text variant='hideOverflow'>
+                  {`${match.radiant_name} vs ${match.dire_name}`}
+                </Text>
               </Cell>
 
               <Cell id='duration'>
                 {getGameDuration(match.duration)}
               </Cell>
 
-              <Cell id='when'>
+              <Cell id='when' variant='lastCell'>
                 {getTimeElapsed(match.start_time)}
               </Cell>
             </tr>
           )
         }
       </Table>
+
+      <BackToTop />
     </Container>
+  )
 }
 
 export default ProMatches

--- a/src/app/components/Matches/ProMatches/styled.js
+++ b/src/app/components/Matches/ProMatches/styled.js
@@ -5,3 +5,10 @@ export const Container = styled.div`
   flex-direction: column;
   justify-content: space-between;
 `
+
+export const PaginationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 2rem;
+`

--- a/src/app/components/Matches/PublicMatches/index.js
+++ b/src/app/components/Matches/PublicMatches/index.js
@@ -1,8 +1,6 @@
-import React, { useEffect } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
+import React, { useState } from 'react'
+import { useSelector } from 'react-redux'
 import { navigate } from '@reach/router'
-
-import { fetchPublicMatches } from 'app/redux/actions/matches'
 
 import {
   getLobbyType,
@@ -15,13 +13,15 @@ import Text from 'app/components/core/Text'
 import Table from 'app/components/core/Table'
 import Cell from 'app/components/core/Table/Cell'
 
+import Pagination from 'app/components/Pagination'
 import Team from 'app/components/MatchResults/Team'
+import BackToTop from 'app/components/BackToTop'
 
-import { Container } from './styled'
+import { Container, PaginationContainer } from './styled'
 
 const PublicMatches = () => {
-  const dispatch = useDispatch()
-  const matches = useSelector(state => state.matches.items.publicMatches)
+  const allMatches = useSelector(state => state.matches.items.publicMatches)
+  const [matches, setMatches] = useState(allMatches.slice(0, 25))
 
   const columns = [
     'Match ID',
@@ -34,18 +34,23 @@ const PublicMatches = () => {
   const handleClick = id =>
     navigate(`/matches/${id}`)
 
-  useEffect(() => {
-    dispatch(fetchPublicMatches())
-  }, [])
-
   return (
     <Container>
-      <Text component='h1'>
-        public matches
-      </Text>
-      <Text padding='1rem 0'>
-        {`showing ${matches.length} matches`}
-      </Text>
+      <PaginationContainer>
+        <div>
+          <Text component='h2' padding='0 0 .5rem 0'>
+            public matches
+          </Text>
+          <Text>
+            {`showing ${matches.length} matches`}
+          </Text>
+        </div>
+
+        <Pagination
+          array={allMatches}
+          setArray={setMatches}
+        />
+      </PaginationContainer>
 
       <Table columns={columns}>
         {
@@ -59,42 +64,40 @@ const PublicMatches = () => {
               </Cell>
 
               <Cell id='info'>
-                <div>
-                  <Text>{getGameMode(match.game_mode)}</Text>
-                  <Text>{getLobbyType(match.lobby_type)}</Text>
-                  <Text>{`avg mmr: ${match.avg_mmr}`}</Text>
-                </div>
+                <Text>{getGameMode(match.game_mode)}</Text>
+                <Text>{getLobbyType(match.lobby_type)}</Text>
+                <Text>{`avg mmr: ${match.avg_mmr}`}</Text>
               </Cell>
 
               <Cell id='sides'>
-                <div>
-                  <Team heroes={
-                    match.radiant_team
-                      .split(',')
-                      .map(hero => parseInt(hero))
-                  }
-                  />
+                <Team heroes={
+                  match.radiant_team
+                    .split(',')
+                    .map(hero => parseInt(hero))
+                }
+                />
 
-                  <Team heroes={
-                    match.dire_team
-                      .split(',')
-                      .map(hero => parseInt(hero))
-                  }
-                  />
-                </div>
+                <Team heroes={
+                  match.dire_team
+                    .split(',')
+                    .map(hero => parseInt(hero))
+                }
+                />
               </Cell>
 
               <Cell id='duration'>
                 {getGameDuration(match.duration)}
               </Cell>
 
-              <Cell id='when'>
+              <Cell id='when' variant='lastCell'>
                 {getTimeElapsed(match.start_time)}
               </Cell>
             </tr>
           )
         }
       </Table>
+
+      <BackToTop />
     </Container>
   )
 }

--- a/src/app/components/Matches/PublicMatches/styled.js
+++ b/src/app/components/Matches/PublicMatches/styled.js
@@ -5,3 +5,10 @@ export const Container = styled.div`
   flex-direction: column;
   justify-content: space-between;
 `
+
+export const PaginationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 2rem;
+`

--- a/src/app/components/Pagination/index.js
+++ b/src/app/components/Pagination/index.js
@@ -1,0 +1,94 @@
+import React, { useEffect, useState } from 'react'
+import PropTypes from 'prop-types'
+
+import Text from 'app/components/core/Text'
+import Button from 'app/components/core/Button'
+
+import { Container } from './styled'
+
+const Pagination = ({ array, setArray }) => {
+  const [current, setCurrent] = useState(0)
+
+  const ITEMS_TO_SHOW = 25
+  const n = Math.ceil(array.length / ITEMS_TO_SHOW)
+  const sliceStart = current * ITEMS_TO_SHOW
+  const sliceEnd =
+    sliceStart + ITEMS_TO_SHOW > array.length
+      ? array.length
+      : sliceStart + ITEMS_TO_SHOW
+
+  const buttonsIndex = [
+    current - 2,
+    current - 1,
+    current + 0,
+    current + 1,
+    current + 2,
+  ]
+
+  const renderButtons = () =>
+    buttonsIndex.map(index =>
+      <Button
+        key={index}
+        minWidth='30px'
+        active={index === current}
+        disabled={index < 0 || index >= n}
+        onClick={() => setCurrent(index)}
+      >
+        {
+          index < 0 || index >= n
+            ? '-'
+            : index + 1
+        }
+      </Button>
+    )
+
+  useEffect(() => {
+    setArray(
+      array.slice(sliceStart, sliceEnd)
+    )
+  }, [current])
+
+  return (
+    <Container>
+      <Text padding='0 0 1rem 0'>
+        {`${sliceStart}-${sliceEnd} / ${array.length}`}
+      </Text>
+
+      <Button
+        onClick={() => setCurrent(0)}
+        disabled={!current}
+      >
+        {'<<'}
+      </Button>
+
+      <Button
+        onClick={() => setCurrent(current - 1)}
+        disabled={!current}
+      >
+        {'<'}
+      </Button>
+
+      {renderButtons()}
+
+      <Button
+        onClick={() => setCurrent(current + 1)}
+        disabled={current === n - 1}
+      >
+        {'>'}
+      </Button>
+      <Button
+        onClick={() => setCurrent(n - 1)}
+        disabled={current === n - 1}
+      >
+        {'>>'}
+      </Button>
+    </Container>
+  )
+}
+
+Pagination.propTypes = {
+  array: PropTypes.array,
+  setArray: PropTypes.func,
+}
+
+export default Pagination

--- a/src/app/components/Pagination/styled.js
+++ b/src/app/components/Pagination/styled.js
@@ -1,0 +1,6 @@
+import styled from 'styled-components'
+
+export const Container = styled.div`
+  text-align: center;
+  padding-bottom: 1rem;
+`

--- a/src/app/components/Players/Player/Heroes/index.js
+++ b/src/app/components/Players/Player/Heroes/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 
 import {
@@ -12,12 +12,19 @@ import Image from 'app/components/core/Image'
 import Table from 'app/components/core/Table'
 import Cell from 'app/components/core/Table/Cell'
 
+import Pagination from 'app/components/Pagination'
 import WinRate from 'app/components/WinRate'
+import BackToTop from 'app/components/BackToTop'
 
-import { Container, Hero } from './styled'
+import {
+  Container,
+  PaginationContainer,
+  Hero,
+} from './styled'
 
 const Heroes = () => {
-  const heroes = useSelector(state => state.players.selected.heroes)
+  const allHeroes = useSelector(state => state.players.selected.heroes)
+  const [heroes, setHeroes] = useState(allHeroes.slice(0, 25))
 
   const columns = [
     'Hero',
@@ -28,12 +35,21 @@ const Heroes = () => {
 
   return !isEmpty(heroes) &&
     <Container>
-      <Text component='h2'>
-        most played
-      </Text>
-      <Text padding='1rem 0'>
-        {`showing ${heroes.length} heroes`}
-      </Text>
+      <PaginationContainer>
+        <div>
+          <Text component='h2' padding='0 0 .5rem 0'>
+            heroes
+          </Text>
+          <Text>
+            {`showing ${heroes.length} heroes`}
+          </Text>
+        </div>
+
+        <Pagination
+          array={allHeroes}
+          setArray={setHeroes}
+        />
+      </PaginationContainer>
 
       <Table columns={columns}>
         {
@@ -46,21 +62,32 @@ const Heroes = () => {
                 </Hero>
               </Cell>
 
-              <Cell id='matches' width='1%'>
-                <WinRate wins={hero.win} total={hero.games} />
+              <Cell id='matches' width='180px'>
+                <WinRate
+                  wins={hero.win}
+                  total={hero.games}
+                />
               </Cell>
 
-              <Cell id='with' width='1%'>
-                <WinRate wins={hero.with_win} total={hero.with_games} />
+              <Cell id='with' width='180px'>
+                <WinRate
+                  wins={hero.with_win}
+                  total={hero.with_games}
+                />
               </Cell>
 
-              <Cell id='against' width='1%'>
-                <WinRate wins={hero.against_win} total={hero.against_games} />
+              <Cell id='against' width='180px'>
+                <WinRate
+                  wins={hero.against_win}
+                  total={hero.against_games}
+                />
               </Cell>
             </tr>
           )
         }
       </Table>
+
+      <BackToTop />
     </Container>
 }
 

--- a/src/app/components/Players/Player/Heroes/styled.js
+++ b/src/app/components/Players/Player/Heroes/styled.js
@@ -5,6 +5,13 @@ export const Container = styled.div`
   flex-direction: column;
 `
 
+export const PaginationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 2rem;
+`
+
 export const Hero = styled.div`
   display: flex;
   align-items: center;

--- a/src/app/components/Players/Player/Index/RecentMatches/index.js
+++ b/src/app/components/Players/Player/Index/RecentMatches/index.js
@@ -55,7 +55,7 @@ const RecentMatches = () => {
                   <HeroPlayed>
                     <Image src={getHeroImage(match.hero_id)} />
 
-                    <Text component='h5' variant='hideOverflow'>
+                    <Text component='h5'>
                       {getHeroLocalizedName(match.hero_id)}
                     </Text>
                   </HeroPlayed>
@@ -66,11 +66,9 @@ const RecentMatches = () => {
                 </Cell>
 
                 <Cell id='info'>
-                  <div>
-                    <Text>{getGameMode(match.game_mode)}</Text>
-                    <Text>{getLobbyType(match.lobby_type)}</Text>
-                    <Text>{getSkillBracket(match.skill)}</Text>
-                  </div>
+                  <Text>{getGameMode(match.game_mode)}</Text>
+                  <Text>{getLobbyType(match.lobby_type)}</Text>
+                  <Text>{getSkillBracket(match.skill)}</Text>
                 </Cell>
 
                 <Cell id='result'>
@@ -85,7 +83,7 @@ const RecentMatches = () => {
                   {getGameDuration(match.duration)}
                 </Cell>
 
-                <Cell id='when'>
+                <Cell id='when' variant='lastCell'>
                   {getTimeElapsed(match.start_time)}
                 </Cell>
               </tr>

--- a/src/app/components/Players/Player/Matches/index.js
+++ b/src/app/components/Players/Player/Matches/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { navigate } from '@reach/router'
 
@@ -18,10 +18,18 @@ import Image from 'app/components/core/Image'
 import Table from 'app/components/core/Table'
 import Cell from 'app/components/core/Table/Cell'
 
-import { Container, HeroPlayed } from './styled'
+import Pagination from 'app/components/Pagination'
+import BackToTop from 'app/components/BackToTop'
+
+import {
+  Container,
+  HeroPlayed,
+  PaginationContainer,
+} from './styled'
 
 const Matches = () => {
-  const matches = useSelector(state => state.players.selected.matches)
+  const allMatches = useSelector(state => state.players.selected.matches)
+  const [matches, setMatches] = useState(allMatches.slice(0, 25))
 
   const columns = [
     'Hero',
@@ -37,12 +45,21 @@ const Matches = () => {
 
   return !isEmpty(matches) &&
     <Container>
-      <Text component='h2'>
-        matches
-      </Text>
-      <Text padding='1rem 0'>
-        {`showing ${matches.length} matches`}
-      </Text>
+      <PaginationContainer>
+        <div>
+          <Text component='h2' padding='0 0 .5rem 0'>
+            matches
+          </Text>
+          <Text>
+            {`showing ${matches.length} matches`}
+          </Text>
+        </div>
+
+        <Pagination
+          array={allMatches}
+          setArray={setMatches}
+        />
+      </PaginationContainer>
 
       <Table columns={columns}>
         {
@@ -51,26 +68,24 @@ const Matches = () => {
               key={match.match_id}
               onClick={() => handleClick(match)}
             >
-              <Cell id='hero'>
+              <Cell id='hero' width='250px'>
                 <HeroPlayed>
                   <Image src={getHeroImage(match.hero_id)} />
 
-                  <Text component='h5' variant='hideOverflow'>
+                  <Text component='h5'>
                     {getHeroLocalizedName(match.hero_id)}
                   </Text>
                 </HeroPlayed>
               </Cell>
 
-              <Cell id='kda'>
+              <Cell id='kda' width='120px'>
                 {`${match.kills}-${match.deaths}-${match.assists}`}
               </Cell>
 
-              <Cell id='info'>
-                <div>
-                  <Text>{getGameMode(match.game_mode)}</Text>
-                  <Text>{getLobbyType(match.lobby_type)}</Text>
-                  <Text>{getSkillBracket(match.skill)}</Text>
-                </div>
+              <Cell id='info' width='200px'>
+                <Text>{getGameMode(match.game_mode)}</Text>
+                <Text>{getLobbyType(match.lobby_type)}</Text>
+                <Text>{getSkillBracket(match.skill)}</Text>
               </Cell>
 
               <Cell id='result'>
@@ -85,13 +100,15 @@ const Matches = () => {
                 {getGameDuration(match.duration)}
               </Cell>
 
-              <Cell id='when'>
+              <Cell id='when' variant='lastCell'>
                 {getTimeElapsed(match.start_time)}
               </Cell>
             </tr>
           )
         }
       </Table>
+
+      <BackToTop />
     </Container>
 }
 

--- a/src/app/components/Players/Player/Matches/styled.js
+++ b/src/app/components/Players/Player/Matches/styled.js
@@ -5,9 +5,17 @@ export const Container = styled.div`
   flex-direction: column;
 `
 
+export const PaginationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 2rem;
+`
+
 export const HeroPlayed = styled.div`
   display: flex;
   align-items: center;
+  width: 200px;
 
   img {
     margin-right: .7rem;

--- a/src/app/components/Players/Player/Peers/index.js
+++ b/src/app/components/Players/Player/Peers/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { navigate } from '@reach/router'
 
@@ -9,12 +9,19 @@ import Text from 'app/components/core/Text'
 import Table from 'app/components/core/Table'
 import Cell from 'app/components/core/Table/Cell'
 
+import Pagination from 'app/components/Pagination'
 import WinRate from 'app/components/WinRate'
+import BackToTop from 'app/components/BackToTop'
 
-import { Container, Account } from './styled'
+import {
+  Container,
+  PaginationContainer,
+  Account,
+} from './styled'
 
 const Peers = () => {
-  const peers = useSelector(state => state.players.selected.peers)
+  const allPeers = useSelector(state => state.players.selected.peers)
+  const [peers, setPeers] = useState(allPeers.slice(0, 25))
 
   const columns = [
     'Friend',
@@ -27,12 +34,21 @@ const Peers = () => {
 
   return !isEmpty(peers) &&
     <Container>
-      <Text component='h2'>
-        friends
-      </Text>
-      <Text padding='1rem 0'>
-        {`showing ${peers.length} friends`}
-      </Text>
+      <PaginationContainer>
+        <div>
+          <Text component='h2' padding='0 0 .5rem 0'>
+            friends
+          </Text>
+          <Text>
+            {`showing ${peers.length} friends`}
+          </Text>
+        </div>
+
+        <Pagination
+          array={allPeers}
+          setArray={setPeers}
+        />
+      </PaginationContainer>
 
       <Table columns={columns}>
         {
@@ -48,17 +64,25 @@ const Peers = () => {
                 </Account>
               </Cell>
 
-              <Cell id='with'>
-                <WinRate wins={peer.with_win} total={peer.with_games} />
+              <Cell id='with' width='180px'>
+                <WinRate
+                  wins={peer.with_win}
+                  total={peer.with_games}
+                />
               </Cell>
 
-              <Cell id='against'>
-                <WinRate wins={peer.against_win} total={peer.against_games} />
+              <Cell id='against' width='180px'>
+                <WinRate
+                  wins={peer.against_win}
+                  total={peer.against_games}
+                />
               </Cell>
             </tr>
           )
         }
       </Table>
+
+      <BackToTop />
     </Container>
 }
 

--- a/src/app/components/Players/Player/Peers/styled.js
+++ b/src/app/components/Players/Player/Peers/styled.js
@@ -5,6 +5,13 @@ export const Container = styled.div`
   flex-direction: column;
 `
 
+export const PaginationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 2rem;
+`
+
 export const Account = styled.div`
   display: flex;
   align-items: center;

--- a/src/app/components/Teams/Team/Index/RecentMatches/index.js
+++ b/src/app/components/Teams/Team/Index/RecentMatches/index.js
@@ -65,7 +65,7 @@ const RecentMatches = () => {
                   {getGameDuration(match.duration)}
                 </Cell>
 
-                <Cell id='when'>
+                <Cell id='when' variant='lastCell'>
                   {getTimeElapsed(match.start_time)}
                 </Cell>
               </tr>

--- a/src/app/components/Teams/Team/Matches/index.js
+++ b/src/app/components/Teams/Team/Matches/index.js
@@ -1,4 +1,4 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { useSelector } from 'react-redux'
 import { navigate } from '@reach/router'
 
@@ -9,10 +9,18 @@ import Text from 'app/components/core/Text'
 import Table from 'app/components/core/Table'
 import Cell from 'app/components/core/Table/Cell'
 
-import { Container, Against } from './styled'
+import Pagination from 'app/components/Pagination'
+import BackToTop from 'app/components/BackToTop'
+
+import {
+  Container,
+  PaginationContainer,
+  Against,
+} from './styled'
 
 const RecentMatches = () => {
-  const matches = useSelector(state => state.teams.selected.matches)
+  const allMatches = useSelector(state => state.teams.selected.matches)
+  const [matches, setMatches] = useState(allMatches.slice(0, 25))
 
   const columns = [
     'League',
@@ -27,52 +35,65 @@ const RecentMatches = () => {
 
   return (
     <Container>
-      <Text component='h2'>
-        matches
-      </Text>
-      <Text padding='1rem 0'>
-        showing 100 matches
-      </Text>
+      <PaginationContainer>
+        <div>
+          <Text component='h2' padding='0 0 .5rem 0'>
+            matches
+          </Text>
+          <Text>
+            {`showing ${matches.length} matches`}
+          </Text>
+        </div>
+
+        <Pagination
+          array={allMatches}
+          setArray={setMatches}
+        />
+      </PaginationContainer>
 
       <Table columns={columns}>
         {
-          matches
-            .filter((match, index) => index < 100)
-            .map(match =>
-              <tr
-                key={match.match_id}
-                onClick={() => handleClick(match.match_id)}
-              >
-                <Cell id='league'>
+          matches.map(match =>
+            <tr
+              key={match.match_id}
+              onClick={() => handleClick(match.match_id)}
+            >
+              <Cell id='league' width='300px'>
+                <Text variant='hideOverflow'>
                   {match.league_name}
-                </Cell>
+                </Text>
+              </Cell>
 
-                <Cell id='against'>
-                  <Against>
-                    <Image src={match.opposing_team_logo} />
-                    <Text>{match.opposing_team_name}</Text>
-                  </Against>
-                </Cell>
+              <Cell id='against' width='300px'>
+                <Against>
+                  <Image src={match.opposing_team_logo} />
+                  <Text variant='hideOverflow'>
+                    {match.opposing_team_name}
+                  </Text>
+                </Against>
+              </Cell>
 
-                <Cell id='result'>
-                  {
-                    match.radiant ^ match.radiant_win
-                      ? <Text variant='loss'>lost match</Text>
-                      : <Text variant='win'>won match</Text>
-                  }
-                </Cell>
+              <Cell id='result'>
+                {
+                  match.radiant ^ match.radiant_win
+                    ? <Text variant='loss'>lost match</Text>
+                    : <Text variant='win'>won match</Text>
+                }
+              </Cell>
 
-                <Cell id='duration'>
-                  {getGameDuration(match.duration)}
-                </Cell>
+              <Cell id='duration'>
+                {getGameDuration(match.duration)}
+              </Cell>
 
-                <Cell id='when'>
-                  {getTimeElapsed(match.start_time)}
-                </Cell>
-              </tr>
-            )
+              <Cell id='when' variant='lastCell'>
+                {getTimeElapsed(match.start_time)}
+              </Cell>
+            </tr>
+          )
         }
       </Table>
+
+      <BackToTop />
     </Container>
   )
 }

--- a/src/app/components/Teams/Team/Matches/styled.js
+++ b/src/app/components/Teams/Team/Matches/styled.js
@@ -3,7 +3,13 @@ import styled from 'styled-components'
 export const Container = styled.div`
   display: flex;
   flex-direction: column;
-  padding-bottom: 3rem;
+`
+
+export const PaginationContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-bottom: 2rem;
 `
 
 export const Against = styled.div`

--- a/src/app/components/core/Button/index.js
+++ b/src/app/components/core/Button/index.js
@@ -1,0 +1,20 @@
+import styled from 'styled-components'
+
+import theme from 'app/helpers/theme'
+
+const Button = styled.button`
+  width: ${({ width }) => width};
+  min-width: ${({ minWidth }) => minWidth};
+  background: ${theme.colors.white};
+  border: none;
+  padding: .5rem;
+  transform: ${({ active }) => active && 'scale(1.25)'};
+  transition: background .3s, font-size .3s;
+
+  &:hover:not([disabled]) {
+    background: ${theme.colors.hover};
+    cursor: pointer;
+  }
+`
+
+export default Button

--- a/src/app/components/core/Table/Cell/index.js
+++ b/src/app/components/core/Table/Cell/index.js
@@ -1,7 +1,16 @@
-import styled from 'styled-components'
+import styled, { css } from 'styled-components'
+
+import theme from 'app/helpers/theme'
 
 const Cell = styled.td`
-  width: ${({ width }) => width || 'auto'};
+  max-width: ${({ width }) => width || 'unset'};
+  
+  ${
+    ({ variant }) => variant &&
+      css`
+        ${theme.variants[variant]}
+      `
+  }
 `
 
 export default Cell

--- a/src/app/components/core/Table/styled.js
+++ b/src/app/components/core/Table/styled.js
@@ -3,6 +3,7 @@ import styled from 'styled-components'
 import theme from 'app/helpers/theme'
 
 export const CoreTable = styled.table`
+  table-layout: fixed;
   border-collapse: collapse;
   color: ${theme.colors.white};
 
@@ -16,11 +17,6 @@ export const CoreTable = styled.table`
 
     &:last-child {
       padding-right: 0;
-    }
-
-    &:last-child[id='when'] {
-      width: 1%;
-      white-space: nowrap;
     }
   }
 

--- a/src/app/helpers/globalStyles.js
+++ b/src/app/helpers/globalStyles.js
@@ -7,6 +7,10 @@ const GlobalStyles = createGlobalStyle`
     padding: 0;
     margin: 0;
     box-sizing: border-box;
+
+    &:focus {
+      outline: none;
+    }
   }
 
   html {

--- a/src/app/helpers/theme.js
+++ b/src/app/helpers/theme.js
@@ -17,13 +17,15 @@ const variants = {
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
   },
-
   win: {
     color: colors.green,
   },
-
   loss: {
     color: colors.red,
+  },
+  lastCell: {
+    width: '1%',
+    whiteSpace: 'nowrap',
   },
 }
 

--- a/src/app/pages/Matches/ProMatches/index.js
+++ b/src/app/pages/Matches/ProMatches/index.js
@@ -1,8 +1,22 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { fetchProMatches } from 'app/redux/actions/matches'
+
+import { isEmpty } from 'app/helpers/utils'
 
 import ProMatches from 'app/components/Matches/ProMatches'
 
-const ProMatchesPage = () =>
-  <ProMatches />
+const ProMatchesPage = () => {
+  const dispatch = useDispatch()
+  const matches = useSelector(state => state.matches.items.proMatches)
+
+  useEffect(() => {
+    dispatch(fetchProMatches())
+  }, [])
+
+  return !isEmpty(matches) &&
+    <ProMatches />
+}
 
 export default ProMatchesPage

--- a/src/app/pages/Matches/PublicMatches/index.js
+++ b/src/app/pages/Matches/PublicMatches/index.js
@@ -1,8 +1,22 @@
-import React from 'react'
+import React, { useEffect } from 'react'
+import { useDispatch, useSelector } from 'react-redux'
+
+import { fetchPublicMatches } from 'app/redux/actions/matches'
+
+import { isEmpty } from 'app/helpers/utils'
 
 import PublicMatches from 'app/components/Matches/PublicMatches'
 
-const PublicMatchesPage = () =>
-  <PublicMatches />
+const ProMatchesPage = () => {
+  const dispatch = useDispatch()
+  const matches = useSelector(state => state.matches.items.publicMatches)
 
-export default PublicMatchesPage
+  useEffect(() => {
+    dispatch(fetchPublicMatches())
+  }, [])
+
+  return !isEmpty(matches) &&
+    <PublicMatches />
+}
+
+export default ProMatchesPage

--- a/src/app/redux/actions/players.js
+++ b/src/app/redux/actions/players.js
@@ -32,7 +32,7 @@ export const fetchSelectedPlayer = id => {
         .then(response => response.json()),
       fetch(`https://api.opendota.com/api/players/${id}/heroes`)
         .then(response => response.json()),
-      fetch(`https://api.opendota.com/api/players/${id}/matches?limit=100`)
+      fetch(`https://api.opendota.com/api/players/${id}/matches`)
         .then(response => response.json()),
       fetch(`https://api.opendota.com/api/players/${id}/peers`)
         .then(response => response.json()),
@@ -45,7 +45,7 @@ export const fetchProPlayers = () => {
     dispatch(resetState())
     dispatch(requestPlayers())
 
-    return fetch('https://api.opendota.com/api/proPlayers?limit=100')
+    return fetch('https://api.opendota.com/api/proPlayers')
       .then(response => response.json())
       .then(data => dispatch(receivePlayers(data)))
   }


### PR DESCRIPTION
Added a Pagination component:
works by receiving an items array and a setItems function. It calculates the number of pages to render, renders 5 navigation buttons dinamically (based on current state) and slices the array according to how many items its supposed to show on the page and the current state.

- added :focus globalStyles reset and variant for tables last cell
- improved styles on core Table
- applied lastCell variant
- added Button core component
- added BackToTop component (just a button with scrollTo(0, 0)
- added Pagination component
- made Matches pages fetch its content (fetch was on components)
- applied Pagination to suitable components
- removed limit query argument from redux fetches