### PR TITLE
FIX: hide rank star when player is immortal rank

### DIFF
--- a/src/app/components/Players/Player/Overview/Rank/index.js
+++ b/src/app/components/Players/Player/Overview/Rank/index.js
@@ -22,7 +22,10 @@ const Rank = () => {
         account.rank_tier
           ? (
             <>
-              <Star src={getStarImage(account.rank_tier)} />
+              <Star
+                src={getStarImage(account.rank_tier)}
+                hide={account.rank_tier === 80}
+              />
               <Medal src={getMedalImage(account.rank_tier)} />
             </>
           )

--- a/src/app/components/Players/Player/Overview/Rank/styled.js
+++ b/src/app/components/Players/Player/Overview/Rank/styled.js
@@ -5,8 +5,9 @@ import CoreImage from 'app/components/core/Image'
 export const Container = styled.div``
 
 export const Star = styled(CoreImage)`
-  width: 150px;
+  display: ${({ hide }) => hide && 'none'};
   position: absolute;
+  width: 150px;
 `
 
 export const Medal = styled(CoreImage)`


### PR DESCRIPTION
Immortal rank has no star, so it needs to be hidden in that case
- added hide prop to Star component
- prop trigges display none