### PR TITLE
Fix/items broken images

### DIFF
--- a/src/app/components/Matches/Match/Team/index.js
+++ b/src/app/components/Matches/Match/Team/index.js
@@ -96,6 +96,7 @@ const Team = ({ players }) => {
                           <Image
                             key={item + index}
                             src={item}
+                            item
                           />
                         )
                     }
@@ -108,6 +109,7 @@ const Team = ({ players }) => {
                           <Image
                             key={item + index}
                             src={item}
+                            item
                           />
                         )
                     }

--- a/src/app/components/core/Image/index.js
+++ b/src/app/components/core/Image/index.js
@@ -7,17 +7,19 @@ import { getPlayerDefaultPortrait } from 'app/helpers/utils'
 
 import { StyledImage } from './styled'
 
-const Image = ({ src, width, className, player }) => {
+const Image = ({ src, width, className, player, item }) => {
   const handleError = event => {
     event.target.src =
       player
         ? getPlayerDefaultPortrait()
-        : noPic
+        : item
+          ? ''
+          : noPic
   }
 
   return (
     <StyledImage
-      src={src || noPic}
+      src={src}
       width={width}
       className={className}
       onError={() => handleError(event)}
@@ -30,6 +32,7 @@ Image.propTypes = {
   width: PropTypes.string,
   className: PropTypes.string,
   player: PropTypes.bool,
+  item: PropTypes.bool,
 }
 
 export default Image


### PR DESCRIPTION
in a Match page, item empty slot was receiving noPic fallback. AN empty string as src is more interesting cause it looks like an empty slot
- added item prop tag to core Image and appropriate logic
- applied item prop tag